### PR TITLE
Android changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,25 +67,7 @@ npm install react-native-ua --save
   project(':react-native-ua').projectDir = file('../node_modules/react-native-ua/android')
   ```
 
-2. Add Urban Airship's repository url in your `android/build.gradle` file:
-
-  ```java
-  // ...
-
-  allprojects {
-      repositories {
-          // ...
-
-          maven {
-              // ...
-
-              url "https://urbanairship.bintray.com/android" // add urban repository url
-          }
-      }
-  }
-  ```
-
-3. Include the `react-native-ua` module in your app compile dependencies, inside the `android/app/build.gradle` file:
+2. Include the `react-native-ua` module in your app compile dependencies, inside the `android/app/build.gradle` file:
 
   ```java
   // ...
@@ -97,34 +79,7 @@ npm install react-native-ua --save
   }
   ```
 
-4. Add to your app manifest (`android/app/src/main/AndroidManifest.xml`) these permissions:
-
-  ```xml
-  <manifest ...>
-
-      // ...
-
-      <application ...>
-
-        // ...
-
-        <receiver
-            android:name="com.globo.reactnativeua.ReactNativeUAReceiver"
-            android:exported="false">
-            <intent-filter>
-                <action android:name="com.urbanairship.push.CHANNEL_UPDATED"/>
-                <action android:name="com.urbanairship.push.OPENED"/>
-                <action android:name="com.urbanairship.push.DISMISSED"/>
-                <action android:name="com.urbanairship.push.RECEIVED"/>
-                <category android:name="${applicationId}"/>
-            </intent-filter>
-        </receiver>
-
-      </application>
-  </manifest>
-  ```
-
-5. Create the `android/app/src/main/assets/airshipconfig.properties` file and update it with your Urban Airship App's data:
+3. Create the `android/app/src/main/assets/airshipconfig.properties` file and update it with your Urban Airship App's data:
 
   ```java
   gcmSender = Your GCM sender ID (Your Google API project number)
@@ -139,7 +94,7 @@ npm install react-native-ua --save
   productionAppSecret = Your Production Secret
   ```
 
-6. Inside `MainActivity.java`, located at `android/app/src/main/java/your/app/domain`, add the `ReactNativeUAPackage` to your app package list:
+4. Inside `MainActivity.java`, located at `android/app/src/main/java/your/app/domain`, add the `ReactNativeUAPackage` to your app package list:
 
   ```java
   // ...

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,9 +17,6 @@ repositories {
         url "$projectDir/../../../react-native/android"
     }
 
-    maven {
-        url  "https://urbanairship.bintray.com/android"
-    }
 }
 
 android {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,18 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.globo.reactnativeua">
+
+    <application>
+        <receiver
+            android:name="com.globo.reactnativeua.ReactNativeUAReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.urbanairship.push.CHANNEL_UPDATED"/>
+                <action android:name="com.urbanairship.push.OPENED"/>
+                <action android:name="com.urbanairship.push.DISMISSED"/>
+                <action android:name="com.urbanairship.push.RECEIVED"/>
+                <category android:name="${applicationId}"/>
+            </intent-filter>
+        </receiver>
+
+    </application>
 </manifest>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -14,5 +14,9 @@
             </intent-filter>
         </receiver>
 
+        <meta-data
+            android:name="com.urbanairship.autopilot"
+            android:value="com.globo.reactnativeua.ReactNativeUAAutoPilot"/>
+
     </application>
 </manifest>

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -5,7 +5,7 @@ import android.app.Application;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-
+import com.urbanairship.Autopilot;
 import com.urbanairship.UAirship;
 
 
@@ -14,7 +14,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     public ReactNativeUA(ReactApplicationContext reactContext, Application application) {
         super(reactContext);
 
-        UAirship.takeOff(application);
+        Autopilot.automaticTakeOff(application);
     }
 
     @Override
@@ -41,5 +41,4 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     public void removeTag(String tag) {
         UAirship.shared().getPushManager().editTags().removeTag(tag).apply();
     }
-
 }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAAutoPilot.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAAutoPilot.java
@@ -1,0 +1,17 @@
+package com.globo.reactnativeua;
+
+import android.util.Log;
+
+import com.urbanairship.Autopilot;
+import com.urbanairship.UAirship;
+
+public class ReactNativeUAAutoPilot extends Autopilot {
+
+    private static final String TAG = "ReactNativeUAAutoPilot";
+
+    @Override
+    public void onAirshipReady(UAirship airship) {
+        Log.w(TAG, "Airship ready!");
+    }
+
+}

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiver.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiver.java
@@ -6,33 +6,37 @@ import android.support.annotation.NonNull;
 import com.urbanairship.AirshipReceiver;
 import com.urbanairship.push.PushMessage;
 
-import com.globo.reactnativeua.ReactNativeUAEventEmitter;
-
 
 public class ReactNativeUAReceiver extends AirshipReceiver {
 
-    private static final String TAG = "RNUAReceiver";
-
     @Override
     protected void onPushReceived(@NonNull Context context, @NonNull PushMessage message, boolean notificationPosted) {
-        ReactNativeUAEventEmitter.getInstance().sendEvent("onPushReceived", message);
+        if (ReactNativeUAEventEmitter.getInstance() != null) {
+            ReactNativeUAEventEmitter.getInstance().sendEvent("onPushReceived", message);
+        }
     }
 
     @Override
     protected void onNotificationPosted(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
-        ReactNativeUAEventEmitter.getInstance().sendEvent("onNotificationPosted", notificationInfo.getMessage());
+        if (ReactNativeUAEventEmitter.getInstance() != null) {
+            ReactNativeUAEventEmitter.getInstance().sendEvent("onNotificationPosted", notificationInfo.getMessage());
+        }
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo) {
-        ReactNativeUAEventEmitter.getInstance().sendEvent("onNotificationOpened", notificationInfo.getMessage());
+        if (ReactNativeUAEventEmitter.getInstance() != null) {
+            ReactNativeUAEventEmitter.getInstance().sendEvent("onNotificationOpened", notificationInfo.getMessage());
+        }
 
         return false;
     }
 
     @Override
     protected boolean onNotificationOpened(@NonNull Context context, @NonNull NotificationInfo notificationInfo, @NonNull ActionButtonInfo actionButtonInfo) {
-        ReactNativeUAEventEmitter.getInstance().sendEvent("onNotificationOpened", notificationInfo.getMessage());
+        if (ReactNativeUAEventEmitter.getInstance() != null) {
+            ReactNativeUAEventEmitter.getInstance().sendEvent("onNotificationOpened", notificationInfo.getMessage());
+        }
 
         return false;
     }


### PR DESCRIPTION
First of all, thanks for providing this module! I am not too familiar with react native, but I did notice a few things that might go wrong. Here are the changes:

**AutoPilot**
It looks like react modules are only initialized in the first activity that is started. The Urban Airship SDK needs to be initialized when the app is started in the background from a push notificaiton. If its not initialized it will throw an illegal state exception about takeOff needing to be called first. Autopilot is a quick solution to this where the UA SDK will look for a class that handles takeOff for the app to ensure everything is initialized before it starts processing pushes.

**Manifest Merger**
Android Manifest merging allows us to remove the step of including the receiver (and now autopilot).

**jcenter**
The Android UA SDK is now open source so we were able to link it to jcenter. We no longer need to specify the UA repo.

**Event Emitter**
Since the application can be started in the background before any react modules are initialized, the application will crash when trying to emit events due to setup not being called. Added a few null checks for safety.

I did not verify my changes actually work. Still trying to test everything out.
