### PR TITLE
Solve closed application to load received notification

### DIFF
--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAPackage.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAPackage.java
@@ -38,6 +38,8 @@ public class ReactNativeUAPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
+        reactContext.addLifecycleEventListener(ReactNativeUAReceiverHelper.setup(reactContext));
+
         ReactNativeUAEventEmitter.setup(reactContext);
 
         modules.add(new ReactNativeUA(reactContext, mainApplication));

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiver.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiver.java
@@ -29,7 +29,8 @@ public class ReactNativeUAReceiver extends AirshipReceiver {
         intent.setAction("com.urbanairship.push.RECEIVED");
         intent.putExtra("com.urbanairship.push.EXTRA_PUSH_MESSAGE_BUNDLE", notificationInfo.getMessage().getPushBundle());
 
-        context.sendBroadcast(intent);
+        if (ReactNativeUAEventEmitter.getInstance() == null) ReactNativeUAReceiverHelper.setup(context).savePushIntent(intent);
+        else context.sendBroadcast(intent);
 
         return false;
     }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiverHelper.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiverHelper.java
@@ -1,0 +1,41 @@
+package com.globo.reactnativeua;
+
+import android.content.Context;
+import android.content.Intent;
+
+import com.facebook.react.bridge.LifecycleEventListener;
+
+
+public class ReactNativeUAReceiverHelper implements LifecycleEventListener {
+
+    private static ReactNativeUAReceiverHelper INSTANCE = null;
+
+    private Context context;
+    private Intent pushIntent;
+
+    private ReactNativeUAReceiverHelper(Context context) { this.context = context; }
+
+    public void savePushIntent(Intent intent) { this.pushIntent = intent; }
+
+    @Override
+    public void onHostResume() {
+        if (pushIntent != null) {
+            context.sendBroadcast(pushIntent);
+            pushIntent = null;
+        }
+    }
+
+    @Override
+    public void onHostPause() { }
+
+    @Override
+    public void onHostDestroy() { }
+
+    public static ReactNativeUAReceiverHelper setup(Context context) {
+        if (ReactNativeUAReceiverHelper.INSTANCE == null) {
+            ReactNativeUAReceiverHelper.INSTANCE = new ReactNativeUAReceiverHelper(context);
+        }
+
+        return ReactNativeUAReceiverHelper.INSTANCE;
+    }
+}


### PR DESCRIPTION
This pull request solve the problem that occurred when the application was closed and a notification was opened. It occurred because the push received event was fired before the ReactNativeEventEmitter instance was created. This solution create a helper that hold the push message intent until the emitter instance is created and then fire the onPushReceived event, this is accomplished using the React Native LifecycleEventListener to fire the event when the application and the react native context are fully loaded.

@evandroeisinger 
@tmpapageorgiou 
@lucasts
