### PR TITLE
Solve background notification load on iOS and make use of the new bridge method on Android

### DIFF
--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -47,4 +47,9 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     public void setNamedUserId(String namedUserID) {
         UAirship.shared().getPushManager().getNamedUser().setId(namedUserID);
     }
+
+    @ReactMethod
+    public void handleBackgroundNotification() {
+        ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).sendPushIntent();
+    }
 }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAPackage.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAPackage.java
@@ -38,8 +38,6 @@ public class ReactNativeUAPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
 
-        reactContext.addLifecycleEventListener(ReactNativeUAReceiverHelper.setup(reactContext));
-
         ReactNativeUAEventEmitter.setup(reactContext);
 
         modules.add(new ReactNativeUA(reactContext, mainApplication));

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiverHelper.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiverHelper.java
@@ -3,10 +3,8 @@ package com.globo.reactnativeua;
 import android.content.Context;
 import android.content.Intent;
 
-import com.facebook.react.bridge.LifecycleEventListener;
 
-
-public class ReactNativeUAReceiverHelper implements LifecycleEventListener {
+public class ReactNativeUAReceiverHelper {
 
     private static ReactNativeUAReceiverHelper INSTANCE = null;
 
@@ -17,19 +15,12 @@ public class ReactNativeUAReceiverHelper implements LifecycleEventListener {
 
     public void savePushIntent(Intent intent) { this.pushIntent = intent; }
 
-    @Override
-    public void onHostResume() {
+    public void sendPushIntent() {
         if (pushIntent != null) {
             context.sendBroadcast(pushIntent);
             pushIntent = null;
         }
     }
-
-    @Override
-    public void onHostPause() { }
-
-    @Override
-    public void onHostDestroy() { }
 
     public static ReactNativeUAReceiverHelper setup(Context context) {
         if (ReactNativeUAReceiverHelper.INSTANCE == null) {

--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ class ReactNativeUA {
         bridge.disableNotification();
     }
 
+    static handle_background_notification () {
+        bridge.handleBackgroundNotification();
+    }
+
     static add_tag (tag) {
         bridge.addTag(tag);
     }

--- a/ios/ReactNativeUAIOS/ReactNativeUAIOS.h
+++ b/ios/ReactNativeUAIOS/ReactNativeUAIOS.h
@@ -2,7 +2,7 @@
 #import "UAPush.h"
 
 @interface ReactNativeUAIOS : NSObject <RCTBridgeModule>
-+ (void)setupUrbanAirship;
++ (void)setupUrbanAirship:(NSDictionary *) launchOptions;
 @end
 
 @interface PushHandler : NSObject <UAPushNotificationDelegate>


### PR DESCRIPTION
This pull request solve the problem that occurred when the application was closed and a notification was opened on iOS. The problem was the same as the Android version, the push opened event was fired before the application main view finish render so the react native was not fully loaded and could not receive a event from the bridge. The solution found was hold the notification, we are doing it using NSUserDefaults, and create a new bridge method that must be called on JavaScript to emit the push notification event.

Lastly to make the comportament of the Android and iOS bridge the same, we change the previous Android solution to use the new handle_background_notification method. With this modification we don't need to make use of the LifeCycleEventListener because will be JavaScript responsibility to call the method to emit the notification event.

@evandroeisinger 
@tmpapageorgiou 
@lucasts
