### PR TITLE
Check if React instance was fully set up before emit event

### DIFF
--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAEventEmitter.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAEventEmitter.java
@@ -34,10 +34,10 @@ public class ReactNativeUAEventEmitter {
     }
 
     public void sendEvent(String eventName, PushMessage message) {
-        if (this.context.hasActiveCatalystInstance()) {
-            this.context
-                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                    .emit("receivedNotification", this.createReactNativeMessageObject(eventName, message));
+        if (this.context.hasActiveCatalystInstance() && this.context.getCurrentActivity() != null) {
+                this.context
+                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                        .emit("receivedNotification", this.createReactNativeMessageObject(eventName, message));
         }
     }
 

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAEventEmitter.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAEventEmitter.java
@@ -34,9 +34,11 @@ public class ReactNativeUAEventEmitter {
     }
 
     public void sendEvent(String eventName, PushMessage message) {
-        this.context
-                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                .emit("receivedNotification", this.createReactNativeMessageObject(eventName, message));
+        if (this.context.hasActiveCatalystInstance()) {
+            this.context
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit("receivedNotification", this.createReactNativeMessageObject(eventName, message));
+        }
     }
 
     public static void setup(ReactContext reactContext) {

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAEventEmitter.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAEventEmitter.java
@@ -21,6 +21,8 @@ public class ReactNativeUAEventEmitter {
 
     private ReactNativeUAEventEmitter(ReactContext reactContext) {
         this.context = reactContext;
+
+        this.context.addLifecycleEventListener(ReactNativeUAReceiverHelper.setup(context));
     }
 
     private ReadableMap createReactNativeMessageObject(CharSequence eventName, PushMessage message) {

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiverHelper.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAReceiverHelper.java
@@ -4,17 +4,17 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 
+import com.facebook.react.bridge.LifecycleEventListener;
 
-public class ReactNativeUAReceiverHelper {
+
+public class ReactNativeUAReceiverHelper implements LifecycleEventListener{
 
     private static ReactNativeUAReceiverHelper INSTANCE = null;
 
     private Context context;
     private Intent pushIntent;
 
-    private ReactNativeUAReceiverHelper(Context context) {
-        this.context = context;
-    }
+    private ReactNativeUAReceiverHelper(Context context) { this.context = context; }
 
     public void savePushIntent(Intent intent) { this.pushIntent = intent; }
 
@@ -44,5 +44,18 @@ public class ReactNativeUAReceiverHelper {
         }
 
         return ReactNativeUAReceiverHelper.INSTANCE;
+    }
+
+    @Override
+    public void onHostResume() {
+        sendPushIntent();
+    }
+
+    @Override
+    public void onHostPause() {
+    }
+
+    @Override
+    public void onHostDestroy() {
     }
 }


### PR DESCRIPTION
This pull request solves the following bugs: 
- error that occurs because ReactContext#getJSModule was not protected by ReactContext#hasActiveCatalystInstance();
- error presented by React Native alert module which says "Tried to show an alert while not attached to an Activity" that was occurring when the application was in foreground and was opened by the notification;
- application was not sending notification events to React when in foreground and was opened by the notification in Android API < 21.
