### PR TITLE
Android custom icon and refactoring

### DIFF
--- a/android/src/main/java/com/globo/reactnativeua/Preferences.java
+++ b/android/src/main/java/com/globo/reactnativeua/Preferences.java
@@ -1,0 +1,48 @@
+package com.globo.reactnativeua;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import com.urbanairship.UAirship;
+
+public class Preferences {
+
+    private final String PREFS_NODE = "preferences";
+    private final String PREFS_ANDROID_SMALL_ICON = "prefs_android_small_icon";
+    private final String PREFS_ANDROID_LARGE_ICON = "prefs_android_large_icon";
+    private static Preferences instance;
+    private SharedPreferences preferences;
+
+    public static Preferences getInstance() {
+        if (instance == null) {
+            instance = new Preferences();
+        }
+        return instance;
+    }
+
+    private Preferences() {
+        preferences = UAirship.getApplicationContext().getSharedPreferences(
+                PREFS_NODE, Context.MODE_PRIVATE);
+    }
+
+    public int getAndroidSmallIconResourceId() {
+        return preferences.getInt(PREFS_ANDROID_SMALL_ICON, -1);
+    }
+
+    public void setAndroidSmallIconResourceId(int iconResourceId) {
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putInt(PREFS_ANDROID_SMALL_ICON, iconResourceId);
+        editor.commit();
+    }
+
+    public int getAndroidLargeIconResourceId() {
+        return preferences.getInt(PREFS_ANDROID_LARGE_ICON, -1);
+    }
+
+    public void setAndroidLargeIconResourceId(int iconResourceId) {
+        SharedPreferences.Editor editor = preferences.edit();
+        editor.putInt(PREFS_ANDROID_LARGE_ICON, iconResourceId);
+        editor.commit();
+    }
+
+}

--- a/android/src/main/java/com/globo/reactnativeua/Preferences.java
+++ b/android/src/main/java/com/globo/reactnativeua/Preferences.java
@@ -26,23 +26,23 @@ public class Preferences {
     }
 
     public int getAndroidSmallIconResourceId() {
-        return preferences.getInt(PREFS_ANDROID_SMALL_ICON, -1);
+        return preferences.getInt(PREFS_ANDROID_SMALL_ICON, 0);
     }
 
     public void setAndroidSmallIconResourceId(int iconResourceId) {
-        SharedPreferences.Editor editor = preferences.edit();
-        editor.putInt(PREFS_ANDROID_SMALL_ICON, iconResourceId);
-        editor.commit();
+        preferences.edit()
+                .putInt(PREFS_ANDROID_SMALL_ICON, iconResourceId)
+                .apply();
     }
 
     public int getAndroidLargeIconResourceId() {
-        return preferences.getInt(PREFS_ANDROID_LARGE_ICON, -1);
+        return preferences.getInt(PREFS_ANDROID_LARGE_ICON, 0);
     }
 
     public void setAndroidLargeIconResourceId(int iconResourceId) {
-        SharedPreferences.Editor editor = preferences.edit();
-        editor.putInt(PREFS_ANDROID_LARGE_ICON, iconResourceId);
-        editor.commit();
+        preferences.edit()
+                .putInt(PREFS_ANDROID_LARGE_ICON, iconResourceId)
+                .apply();
     }
 
 }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -2,7 +2,6 @@ package com.globo.reactnativeua;
 
 import android.Manifest;
 import android.app.Activity;
-import android.app.Application;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.support.annotation.NonNull;
@@ -12,7 +11,6 @@ import android.util.Log;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-
 import com.urbanairship.Autopilot;
 import com.urbanairship.UAirship;
 import com.urbanairship.actions.Action;
@@ -21,14 +19,18 @@ import com.urbanairship.actions.ActionCompletionCallback;
 import com.urbanairship.actions.ActionResult;
 import com.urbanairship.actions.ActionRunRequest;
 import com.urbanairship.actions.ActionValue;
+import com.urbanairship.push.notifications.DefaultNotificationFactory;
+import com.urbanairship.push.notifications.NotificationFactory;
 
 
 public class ReactNativeUA extends ReactContextBaseJavaModule {
 
-    public ReactNativeUA(ReactApplicationContext reactContext, Application application) {
+    public ReactNativeUA(final ReactApplicationContext reactContext) {
         super(reactContext);
 
-        Autopilot.automaticTakeOff(application.getApplicationContext());
+        Autopilot.automaticTakeOff(getReactApplicationContext());
+
+        setIcon("ic_notification");
     }
 
     @Override
@@ -84,17 +86,16 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     @ReactMethod
     public void handleBackgroundNotification() {
         Activity activity = getCurrentActivity();
-
-        if (activity != null) ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).sendPushIntent();
+        if (activity != null) {
+            ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).sendPushIntent();
+        }
     }
 
     @ReactMethod
     public void enableActionUrl() {
         Activity activity = getCurrentActivity();
-
         if (activity != null) {
             ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).setActionUrl(true);
-
             Log.d("ActionUrl", "Enable default action url behaviour -> True");
         }
     }
@@ -102,10 +103,8 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     @ReactMethod
     public void disableActionUrl() {
         Activity activity = getCurrentActivity();
-
         if (activity != null) {
             ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).setActionUrl(false);
-
             Log.d("ActionUrl", "Disable default action url behaviour -> False");
         }
     }
@@ -116,7 +115,6 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
 
         if (activity != null) {
             if (shouldRequestPermissions(activity)) {
-
                 ActionRunRequest.createRequest(new Action() {
                     @NonNull
                     @Override
@@ -124,28 +122,26 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
                         int[] result = requestPermissions(Manifest.permission.ACCESS_COARSE_LOCATION,
                                 Manifest.permission.ACCESS_FINE_LOCATION);
 
-                        for (int i = 0; i < result.length; i++)
-                            if (result[i] == PackageManager.PERMISSION_GRANTED)
+                        for (int i = 0; i < result.length; i++) {
+                            if (result[i] == PackageManager.PERMISSION_GRANTED) {
                                 return ActionResult.newResult(ActionValue.wrap(true));
-
+                            }
+                        }
                         return ActionResult.newResult(ActionValue.wrap(false));
                     }
                 }).run(new ActionCompletionCallback() {
                     @Override
                     public void onFinish(ActionArguments arguments, ActionResult result) {
-
-                        if (result.getValue().getBoolean(false))
+                        if (result.getValue().getBoolean(false)) {
                             UAirship.shared().getLocationManager().setLocationUpdatesEnabled(true);
+                        }
                     }
                 });
 
             } else {
-
                 UAirship.shared().getLocationManager().setLocationUpdatesEnabled(true);
-
             }
         }
-
     }
 
     private boolean shouldRequestPermissions(Activity activity) {
@@ -156,4 +152,51 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
 
         return corseLocation == PackageManager.PERMISSION_DENIED && fineLocation == PackageManager.PERMISSION_DENIED;
     }
+
+    @ReactMethod
+    public void setIcon(String iconName) {
+        int iconId = getImageResourceId(iconName);
+        if (iconId > 0) {
+            DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
+            defaultNotifFactory.setSmallIconId(iconId);
+            UAirship.shared().getPushManager().setNotificationFactory(defaultNotifFactory);
+        }
+    }
+
+    @ReactMethod
+    public void setLargeIcon(String iconName) {
+        int iconId = getImageResourceId(iconName);
+        if (iconId > 0) {
+            DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
+            defaultNotifFactory.setLargeIcon(iconId);
+            UAirship.shared().getPushManager().setNotificationFactory(defaultNotifFactory);
+        }
+    }
+
+    private DefaultNotificationFactory getDefaultNotificationFactory() {
+        final NotificationFactory notifFactory = UAirship.shared().getPushManager().getNotificationFactory();
+        if (notifFactory instanceof DefaultNotificationFactory) {
+            return (DefaultNotificationFactory) notifFactory;
+        }
+        return new DefaultNotificationFactory(getReactApplicationContext());
+    }
+
+    private int getImageResourceId(String imageName) {
+        if (imageName == null || imageName.length() <= 0) {
+            return -1;
+        }
+        int imageId = getImageResourceId(imageName, "drawable");
+        if (imageId <= 0) {
+            imageId = getImageResourceId(imageName, "mipmap");
+        }
+        return imageId;
+    }
+
+    private int getImageResourceId(String imageName, String imageResourceType) {
+        return getReactApplicationContext().getResources().getIdentifier(
+                imageName,
+                imageResourceType,
+                getReactApplicationContext().getPackageName());
+    }
+
 }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -27,10 +27,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
 
     public ReactNativeUA(final ReactApplicationContext reactContext) {
         super(reactContext);
-
         Autopilot.automaticTakeOff(getReactApplicationContext());
-
-        setIcon("ic_notification");
     }
 
     @Override

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -151,7 +151,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setIcon(String iconName) {
+    public void setAndroidSmallIcon(String iconName) {
         int iconId = getImageResourceId(iconName);
         if (iconId > 0) {
             DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
@@ -161,7 +161,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void setLargeIcon(String iconName) {
+    public void setAndroidLargeIcon(String iconName) {
         int iconId = getImageResourceId(iconName);
         if (iconId > 0) {
             DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -82,28 +82,19 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void handleBackgroundNotification() {
-        Activity activity = getCurrentActivity();
-        if (activity != null) {
-            ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).sendPushIntent();
-        }
+        ReactNativeUAReceiverHelper.setup(getReactApplicationContext()).sendPushIntent();
     }
 
     @ReactMethod
     public void enableActionUrl() {
-        Activity activity = getCurrentActivity();
-        if (activity != null) {
-            ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).setActionUrl(true);
-            Log.d("ActionUrl", "Enable default action url behaviour -> True");
-        }
+        ReactNativeUAReceiverHelper.setup(getReactApplicationContext()).setActionUrl(true);
+        Log.d("ActionUrl", "Enable default action url behaviour -> True");
     }
 
     @ReactMethod
     public void disableActionUrl() {
-        Activity activity = getCurrentActivity();
-        if (activity != null) {
-            ReactNativeUAReceiverHelper.setup(getCurrentActivity().getApplicationContext()).setActionUrl(false);
-            Log.d("ActionUrl", "Disable default action url behaviour -> False");
-        }
+        ReactNativeUAReceiverHelper.setup(getReactApplicationContext()).setActionUrl(false);
+        Log.d("ActionUrl", "Disable default action url behaviour -> False");
     }
 
     @ReactMethod
@@ -154,6 +145,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     public void setAndroidSmallIcon(String iconName) {
         int iconId = getImageResourceId(iconName);
         if (iconId > 0) {
+            Preferences.getInstance().setAndroidSmallIconResourceId(iconId);
             DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
             defaultNotifFactory.setSmallIconId(iconId);
             UAirship.shared().getPushManager().setNotificationFactory(defaultNotifFactory);
@@ -164,6 +156,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     public void setAndroidLargeIcon(String iconName) {
         int iconId = getImageResourceId(iconName);
         if (iconId > 0) {
+            Preferences.getInstance().setAndroidLargeIconResourceId(iconId);
             DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
             defaultNotifFactory.setLargeIcon(iconId);
             UAirship.shared().getPushManager().setNotificationFactory(defaultNotifFactory);
@@ -175,7 +168,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
         if (notifFactory instanceof DefaultNotificationFactory) {
             return (DefaultNotificationFactory) notifFactory;
         }
-        return new DefaultNotificationFactory(getReactApplicationContext());
+        return new DefaultNotificationFactory(UAirship.getApplicationContext());
     }
 
     private int getImageResourceId(String imageName) {

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -144,7 +144,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setAndroidSmallIcon(String iconName) {
         int iconId = getImageResourceId(iconName);
-        if (iconId > 0) {
+        if (iconId != 0) {
             Preferences.getInstance().setAndroidSmallIconResourceId(iconId);
             DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
             defaultNotifFactory.setSmallIconId(iconId);
@@ -155,7 +155,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
     @ReactMethod
     public void setAndroidLargeIcon(String iconName) {
         int iconId = getImageResourceId(iconName);
-        if (iconId > 0) {
+        if (iconId != 0) {
             Preferences.getInstance().setAndroidLargeIconResourceId(iconId);
             DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
             defaultNotifFactory.setLargeIcon(iconId);
@@ -176,7 +176,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
             return -1;
         }
         int imageId = getImageResourceId(imageName, "drawable");
-        if (imageId <= 0) {
+        if (imageId == 0) {
             imageId = getImageResourceId(imageName, "mipmap");
         }
         return imageId;

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAAutoPilot.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAAutoPilot.java
@@ -5,6 +5,8 @@ import android.util.Log;
 import com.urbanairship.Autopilot;
 import com.urbanairship.UAirship;
 import com.urbanairship.actions.OpenExternalUrlAction;
+import com.urbanairship.push.notifications.DefaultNotificationFactory;
+import com.urbanairship.push.notifications.NotificationFactory;
 
 public class ReactNativeUAAutoPilot extends Autopilot {
 
@@ -15,6 +17,25 @@ public class ReactNativeUAAutoPilot extends Autopilot {
 		UAirship.shared().getActionRegistry().unregisterAction(OpenExternalUrlAction.DEFAULT_REGISTRY_NAME);
 
         Log.w(TAG, "Airship ready!");
+
+        // Customize icons
+        DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
+        int smallIconResourceId = Preferences.getInstance().getAndroidSmallIconResourceId();
+        if (smallIconResourceId > 0) {
+            defaultNotifFactory.setSmallIconId(smallIconResourceId);
+        }
+        int largeIconResourceId = Preferences.getInstance().getAndroidLargeIconResourceId();
+        if (largeIconResourceId > 0) {
+            defaultNotifFactory.setLargeIcon(largeIconResourceId);
+        }
+        UAirship.shared().getPushManager().setNotificationFactory(defaultNotifFactory);
     }
 
+    private DefaultNotificationFactory getDefaultNotificationFactory() {
+        final NotificationFactory notifFactory = UAirship.shared().getPushManager().getNotificationFactory();
+        if (notifFactory instanceof DefaultNotificationFactory) {
+            return (DefaultNotificationFactory) notifFactory;
+        }
+        return new DefaultNotificationFactory(UAirship.getApplicationContext());
+    }
 }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAAutoPilot.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAAutoPilot.java
@@ -21,11 +21,11 @@ public class ReactNativeUAAutoPilot extends Autopilot {
         // Customize icons
         DefaultNotificationFactory defaultNotifFactory = getDefaultNotificationFactory();
         int smallIconResourceId = Preferences.getInstance().getAndroidSmallIconResourceId();
-        if (smallIconResourceId > 0) {
+        if (smallIconResourceId != 0) {
             defaultNotifFactory.setSmallIconId(smallIconResourceId);
         }
         int largeIconResourceId = Preferences.getInstance().getAndroidLargeIconResourceId();
-        if (largeIconResourceId > 0) {
+        if (largeIconResourceId != 0) {
             defaultNotifFactory.setLargeIcon(largeIconResourceId);
         }
         UAirship.shared().getPushManager().setNotificationFactory(defaultNotifFactory);

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUAPackage.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUAPackage.java
@@ -1,7 +1,5 @@
 package com.globo.reactnativeua;
 
-import android.app.Application;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -12,17 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import com.globo.reactnativeua.ReactNativeUA;
-import com.globo.reactnativeua.ReactNativeUAEventEmitter;
-
-
 public class ReactNativeUAPackage implements ReactPackage {
-
-    private Application mainApplication;
-
-    public ReactNativeUAPackage(Application application) {
-        mainApplication = application;
-    }
 
     @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
@@ -37,11 +25,8 @@ public class ReactNativeUAPackage implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
-
         ReactNativeUAEventEmitter.setup(reactContext);
-
-        modules.add(new ReactNativeUA(reactContext, mainApplication));
-
+        modules.add(new ReactNativeUA(reactContext));
         return modules;
     }
 

--- a/index.js
+++ b/index.js
@@ -106,12 +106,12 @@ class ReactNativeUA {
         notification_listeners.push(callback);
     }
 
-    static set_icon (iconName) {
-        bridge.setIcon(iconName);
+    static set_android_small_icon (iconName) {
+        bridge.setAndroidSmallIcon(iconName);
     }
 
-    static set_large_icon (iconName) {
-        bridge.setLargeIcon(iconName);
+    static set_android_large_icon (iconName) {
+        bridge.setAndroidLargeIcon(iconName);
     }
 
 }

--- a/index.js
+++ b/index.js
@@ -106,12 +106,16 @@ class ReactNativeUA {
         notification_listeners.push(callback);
     }
 
-    static set_android_small_icon (iconName) {
-        bridge.setAndroidSmallIcon(iconName);
+    static set_android_small_icon(iconName) {
+        if (Platform.OS === 'android') {
+            bridge.setAndroidSmallIcon(iconName);
+        }
     }
 
     static set_android_large_icon (iconName) {
-        bridge.setAndroidLargeIcon(iconName);
+        if (Platform.OS === 'android') {
+            bridge.setAndroidLargeIcon(iconName);
+        }
     }
 
 }

--- a/index.js
+++ b/index.js
@@ -106,6 +106,14 @@ class ReactNativeUA {
         notification_listeners.push(callback);
     }
 
+    static set_icon (iconName) {
+        bridge.setIcon(iconName);
+    }
+
+    static set_large_icon (iconName) {
+        bridge.setLargeIcon(iconName);
+    }
+
 }
 
 export default ReactNativeUA


### PR DESCRIPTION
Hi guys!
I made some changes to the framework and would like you to revise before approving them:
- Added some methods for customizing notification icons on Android, since it lets you add the SmallIcon and LargeIcon.
- Refactored code that uses the Application class and the ApplicationContext method. To use them it received the Application as a parameter in ReactNativeUAPackage class. But this was not necessary because the ReactNative offers the getReactApplicationContext () method.
