### PR TITLE
Updates for Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,11 @@ npm install react-native-ua --save
   public class MainApplication extends Application implements ReactApplication {
       // ...
 
-      public final Application application = this; // get application
-
       @Override
       protected List<ReactPackage> getPackages() {
           return Arrays.<ReactPackage>asList(
               // ...
-              new ReactNativeUAPackage(application) // set react-native-ua package using application
+              new ReactNativeUAPackage() // set react-native-ua package using application
           );
       }
   }

--- a/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
+++ b/android/src/main/java/com/globo/reactnativeua/ReactNativeUA.java
@@ -56,7 +56,7 @@ public class ReactNativeUA extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void setNamedUserId(String namedUserID) {
-        UAirship.shared().getPushManager().getNamedUser().setId(namedUserID);
+        UAirship.shared().getNamedUser().setId(namedUserID);
     }
 
     @ReactMethod


### PR DESCRIPTION
## Purpose

The readme was a little out of date for the Android setup. Also, the newest Urban Airship SDK has deprecated the previously used call access `namedUser`.
