### PR TITLE
Allow programmatic configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ npm install react-native-ua --save
     node_modules/react-native-ua/ios/Libraries/Airship/AirshipResources.bundle
     ```
 
-8. Inside `AppDelegate.m`, import `ReactNativeUAIOS.h` and call the module with `[ReactNativeUAIOS setupUrbanAirship:launchOptions]`. Follow the example below:
+8. Inside `AppDelegate.m`, import `ReactNativeUAIOS.h` and setup the module. Follow the example below:
 
   ```objective-c
   #import "ReactNativeUAIOS.h"
@@ -162,9 +162,13 @@ npm install react-native-ua --save
 
   - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
   {
-    // setup react native urban airship
+    // setup react native urban airship using AirshipConfig.plist (the default way)
     [ReactNativeUAIOS setupUrbanAirship:launchOptions];
-
+    
+    // OR setup react native urban airship programmatically. The following example use the content of AirshipConfig-dev.plist instead of the default AirshipConfig.plist
+    NSString *configPath = [[NSBundle mainBundle] pathForResource:@"AirshipConfig-dev" ofType:@"plist"];
+    UAConfig *config = [UAConfig configWithContentsOfFile:configPath];
+    [ReactNativeUAIOS setupUrbanAirship:launchOptions withConfig:config];
     // ...
   }
 

--- a/ios/ReactNativeUAIOS/ReactNativeUAIOS.h
+++ b/ios/ReactNativeUAIOS/ReactNativeUAIOS.h
@@ -3,6 +3,7 @@
 
 @interface ReactNativeUAIOS : NSObject <RCTBridgeModule>
 + (void)setupUrbanAirship:(NSDictionary *) launchOptions;
++ (void)setupUrbanAirship:(NSDictionary *) launchOptions withConfig:(UAConfig *) config;
 @end
 
 @interface PushHandler : NSObject <UAPushNotificationDelegate>

--- a/ios/ReactNativeUAIOS/ReactNativeUAIOS.m
+++ b/ios/ReactNativeUAIOS/ReactNativeUAIOS.m
@@ -19,8 +19,10 @@ static PushHandler *pushHandler = nil;
 }
 
 + (void)setupUrbanAirship:(NSDictionary *) launchOptions {
-    UAConfig *config = [UAConfig defaultConfig];
+    [self setupUrbanAirship:launchOptions withConfig:[UAConfig defaultConfig]];
+}
 
++ (void)setupUrbanAirship:(NSDictionary *) launchOptions withConfig:(UAConfig *)config {
     [UAirship takeOff:config];
 
     pushHandler = [[PushHandler alloc] init];


### PR DESCRIPTION
## Purpose

I often end up preferring programmatic setup of Urban Airship (I find it easier when dealing with multiple build environments). This simply adds a method to allow the developer to pass a `UAConfig` object if they want from the `AppDelegate` in the iOS app.

Since Android is setup with `Autopilot`, this can already be achieved by subclassing `ReactNativeUAAutoPilot` and plugging the subclass in `AndroidManifest` like so:
```
      <meta-data
        tools:replace="android:value"
        android:name="com.urbanairship.autopilot"
        android:value="com.my.package.MyAutopilot"/>
```